### PR TITLE
feat: print logs when each file is uploaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ function publish(options) {
 
     function onEnd(err) {
       if (!err) {
+        gutil.log(gutil.colors.green("[Uploaded] "), key);
         distFiles.push(key);
         cb();
       } else {
@@ -64,9 +65,6 @@ function publish(options) {
     gutil.log('OSS publish finished,  %s files published', gutil.colors.cyan.underline(distFiles.length));
     gutil.log('dist bucket: %s', gutil.colors.cyan(oss.bucket));
     gutil.log('dist root: %s', gutil.colors.cyan(keyBase));
-    distFiles.forEach(function (key) {
-      gutil.log('file: %s', key);
-    });
     cb();
   });
 }


### PR DESCRIPTION
每次上传成功一个文件都打印日志，和其他的 library 保持一致，比较直观
